### PR TITLE
[ATLAS-2343] Client-side PGBouncer | Allow stats user and password to be set for monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Some settings are configurable through app config vars at runtime. Refer to the 
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)
 
+## Monitoring
+
+You can set `PGBOUNCER_STATS_USER` and `PGBOUNCER_STATS_PASSWORD` to enable Datadog (or other provider) monitoring.
+
 ## Using the edge version of the buildpack
 
 The `heroku/pgbouncer` buildpack points to the latest stable version of the buildpack published in the [Buildpack Registry](https://devcenter.heroku.com/articles/buildpack-registry). To use the latest version of the buildpack (the code in this repository, run the following command:

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -24,6 +24,7 @@ auth_file = $CONFIG_DIR/users.txt
 server_tls_sslmode = prefer
 server_tls_protocols = secure
 server_tls_ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
+stats_users = ${PGBOUNCER_STATS_USER}
 
 ; When server connection is released back to pool:
 ;   session      - after client disconnects
@@ -95,5 +96,12 @@ EOFEOF
 
   (( n += 1 ))
 done
+
+if [[ -n ${PGBOUNCER_STATS_USER} ]]; then
+  DB_MD5_STATS_PASS="md5"$(echo -n "${PGBOUNCER_STATS_PASSWORD}""${PGBOUNCER_STATS_USER}" | md5sum | awk '{print $1}')
+  cat >> "$CONFIG_DIR/users.txt" << EOFEOF
+"$PGBOUNCER_STATS_USER" "$DB_MD5_STATS_PASS"
+EOFEOF
+fi
 
 chmod go-rwx "$CONFIG_DIR"/*


### PR DESCRIPTION
Stats user is needed to enable the Datadog PGBouncer integration.

Set via environment variables `PGBOUNCER_STATS_USER` and `PGBOUNCER_STATS_PASSWORD`