### PR TITLE
Ignore SIGHUP & SIGINT for the bash script

### DIFF
--- a/bin/start-pgbouncer
+++ b/bin/start-pgbouncer
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Adapted from https://github.com/ryandotsmith/nginx-buildpack/
 
+export PGBOUNCER_SLEEP_BEFORE_SIGINT=${PGBOUNCER_SLEEP_BEFORE_SIGINT:-28}
+
 function is-pgbouncer-service-enabled() {
   if ! is-enabled "${PGBOUNCER_ENABLED:-1}"; then
     at pgbouncer-disabled
@@ -102,7 +104,7 @@ aux-start() {
     # Translate SIGHUP to the appropriate signal to stop the child (anything
     # except SIGTERM which is ignored). This *will* cancel the wait and may
     # lead to the outer subshell exiting before the aux process
-    trap "kill -$signal $!" SIGHUP
+    trap "sleep ${PGBOUNCER_SLEEP_BEFORE_SIGINT}; kill -$signal $!" SIGHUP
 
     # Wait for child to finish, either by crash or by $signal
     wait

--- a/bin/start-pgbouncer-as-service
+++ b/bin/start-pgbouncer-as-service
@@ -53,14 +53,7 @@ function main() {
   local stderr
   stderr="$(mktemp)"
 
-  trap '' SIGTERM
-
   [[ -x bin/start-pgbouncer ]] && bin/start-pgbouncer /bin/bash -c "while true; do sleep 10000; done" 2>"${stderr}" &
-
-  # Translate SIGHUP to the appropriate signal to stop the child (anything
-  # except SIGTERM which is ignored). This *will* cancel the wait and may
-  # lead to the outer subshell exiting before the aux process
-  trap "sleep 25; kill -SIGINT $!" SIGHUP
 
   sleep 1
 

--- a/bin/start-pgbouncer-as-service
+++ b/bin/start-pgbouncer-as-service
@@ -60,7 +60,7 @@ function main() {
   # Translate SIGHUP to the appropriate signal to stop the child (anything
   # except SIGTERM which is ignored). This *will* cancel the wait and may
   # lead to the outer subshell exiting before the aux process
-  trap "kill -SIGINT $!" SIGHUP
+  trap "sleep 25; kill -SIGINT $!" SIGHUP
 
   sleep 1
 

--- a/bin/start-pgbouncer-as-service
+++ b/bin/start-pgbouncer-as-service
@@ -11,11 +11,12 @@ function inf() {
 }
 
 function err() {
-   echo -e "ERROR: $* "
+  echo -e "ERROR: $* "
 }
 
 function is-enabled() {
-  ( shopt -s extglob nocasematch
+  (
+    shopt -s extglob nocasematch
     [[ $1 == @(1|true|yes|on) ]]
   )
 }
@@ -52,8 +53,14 @@ function main() {
   local stderr
   stderr="$(mktemp)"
 
-  # Start PgBouncer process in the background
+  trap '' SIGTERM
+
   [[ -x bin/start-pgbouncer ]] && bin/start-pgbouncer /bin/bash -c "while true; do sleep 10000; done" 2>"${stderr}" &
+
+  # Translate SIGHUP to the appropriate signal to stop the child (anything
+  # except SIGTERM which is ignored). This *will* cancel the wait and may
+  # lead to the outer subshell exiting before the aux process
+  trap "kill -SIGINT $!" SIGHUP
 
   sleep 1
 
@@ -63,7 +70,7 @@ function main() {
   PGBOUNCER_BUILD_PACK_PID=$(pgbouncer-current-pid)
   export PGBOUNCER_BUILD_PACK_PID
 
-  if [[ -n ${PGBOUNCER_BUILD_PACK_PID} && ${PGBOUNCER_BUILD_PACK_PID} -gt 0 ]] ; then
+  if [[ -n ${PGBOUNCER_BUILD_PACK_PID} && ${PGBOUNCER_BUILD_PACK_PID} -gt 0 ]]; then
     set +e
     mkdir -p tmp/pids || true
     echo "${PGBOUNCER_BUILD_PACK_PID}" > tmp/pids/pgbouncer.pid


### PR DESCRIPTION
This is an attempt to prevent pgbouncer from dying prior to ruby services on the dyno.

It is work in progress.

## What's needed?

To understand the process of rolling restarts at Heroku and if multiple services are running on a dyno (such as puma, pgbouncer and Datadog agent), what signal(s) do they receive when the dyno is still receiving traffic but is marked for deletion.